### PR TITLE
Example for issue #31

### DIFF
--- a/Gpufit/examples/Double_Exp_Example.cpp
+++ b/Gpufit/examples/Double_Exp_Example.cpp
@@ -1,0 +1,127 @@
+#include "../gpufit.h"
+#include <array>
+#include <iostream>
+#include <fstream>
+using namespace std;
+
+void dual_gpufit()
+{
+	// model: y =	a*e^(b*x)+c*e^(d*x);
+
+	std::size_t const n_points{ 8 };
+	std::size_t const n_model_parameters{ 4 };
+
+	char timevalue[] = "PATH//TO//samples.dat";
+	fstream fileout(timevalue, ios::in | ios::binary);
+	streampos begin, end;
+	fileout.seekg(0, ios::beg);
+	begin = fileout.tellg();
+	fileout.seekg(0, ios::end);
+	end = fileout.tellg();
+
+	std::size_t filebyteSize = (end - begin);
+	cout << "filebyteSize = " << filebyteSize << endl;
+	std::size_t n_fits = filebyteSize / 4 / 8;//float type  4 bytes, n_points = 8
+
+	cout << "nfits = " << n_fits << endl;
+	//user_info fron data file 
+	fileout.seekg(0, ios::beg);
+	float* user_info = new float[n_points* n_fits]();
+	fileout.read(reinterpret_cast<char*>(user_info), n_fits * n_points * sizeof(float));
+	fileout.close();
+
+	int const model_id = DUAL_EXP;
+
+	float *initial_parameters = new float[n_fits * n_model_parameters]();
+	for (size_t i = 0; i != n_fits; i++)
+	{
+		initial_parameters[i * n_model_parameters + 0] = 860.f;
+		initial_parameters[i * n_model_parameters + 1] = -0.0448;
+		initial_parameters[i * n_model_parameters + 2] = -860.f;
+		initial_parameters[i * n_model_parameters + 3] = -0.1429f;
+	}
+
+	float * data = new float[n_points * n_fits];
+	for (size_t i = 0; i != n_fits; i++)
+	{
+		data[i*n_points + 0] = 20.f;
+		data[i*n_points + 1] = 110.f;
+		data[i*n_points + 2] = 180.f;
+		data[i*n_points + 3] = 260.f;
+		data[i*n_points + 4] = 260.f;
+		data[i*n_points + 5] = 180.f;
+		data[i*n_points + 6] = 110.f;
+		data[i*n_points + 7] = 20.f;
+	}
+
+
+	// tolerance
+	float const tolerance = 0.000001f;
+	// maximum number of iterations
+	int const max_number_iterations = 10;
+	// estimator ID
+	int const estimator_id = LSE;
+	// parameters to fit (all of them)
+	std::vector< int > parameters_to_fit(n_model_parameters, 1);
+
+	// output parameters
+	float * output_parameters = new float[n_model_parameters * n_fits]();
+	int *output_states = new int[n_fits]();
+	float * output_chi_square = new float[n_fits]();
+	int *output_n_iterations = new int[n_fits]();
+	int const gpu_status
+		= gpufit
+		(
+			n_fits,
+			n_points,
+			data,
+			0,
+			model_id,
+			initial_parameters,
+			tolerance,
+			max_number_iterations,
+			parameters_to_fit.data(),
+			estimator_id,
+			n_points * n_fits * sizeof(float),
+			reinterpret_cast<char *>(user_info),
+			output_parameters,
+			output_states,
+			output_chi_square,
+			output_n_iterations
+		);
+
+	delete[]initial_parameters;
+	delete[]data;
+	delete[]user_info;
+	delete[]output_chi_square;
+	delete[]output_n_iterations;
+	delete[]output_states;
+
+	int i = 0;
+	while (i<n_fits) {
+		cout << "current n point parameters :" << i << endl;
+		std::cout << "para.1 = " << output_parameters[0 + i] << std::endl;
+		std::cout << "para.2 = " << output_parameters[1 + i] << std::endl;
+		std::cout << "para.3 = " << output_parameters[2 + i] << std::endl;
+		std::cout << "para.4 = " << output_parameters[3 + i] << std::endl;
+		cout << endl;
+		//std::cout << "para.1 = " << output_parameters.at(4+i) << std::endl;
+		//std::cout << "para.2 = " << output_parameters.at(5+i) << std::endl;
+		//std::cout << "para.3 = " << output_parameters.at(6+i) << std::endl;
+		//std::cout << "para.4 = " << output_parameters.at(7+i) << std::endl;
+		i += n_fits / 5;
+
+	}
+	delete[]output_parameters;
+}
+
+int main()
+{
+	dual_gpufit();
+
+	std::cout << std::endl << "Example completed!" << std::endl;
+	std::cout << "Press ENTER to exit" << std::endl;
+	std::getchar();
+
+	return 0;
+}

--- a/Gpufit/models/dual_exp.cuh
+++ b/Gpufit/models/dual_exp.cuh
@@ -1,0 +1,122 @@
+#ifndef GPUFIT_DUALEXP_CUH_INCLUDED
+#define GPUFIT_DUALEXP_CUH_INCLUDED
+
+/* Description of the DUALEXP function
+* ==============================================
+*
+* This function calculates the values of one-dimensional gauss model functions
+* and their partial derivatives with respect to the model parameters. 
+*
+* This function makes use of the user information data to pass in the 
+* independent variables (X values) corresponding to the data.  The X values
+* must be of type float.
+*
+* There are three possibilities regarding the X values:
+*
+*   No X values provided: 
+*
+*       If no user information is provided, the (X) coordinate of the 
+*       first data value is assumed to be (0.0).  In this case, for a 
+*       fit size of M data points, the (X) coordinates of the data are 
+*       simply the corresponding array index values of the data array, 
+*       starting from zero.
+*
+*   X values provided for one fit:
+*
+*       If the user_info array contains the X values for one fit, then 
+*       the same X values will be used for all fits.  In this case, the 
+*       size of the user_info array (in bytes) must equal 
+*       sizeof(float) * n_points.
+*
+*   Unique X values provided for all fits:
+*
+*       In this case, the user_info array must contain X values for each
+*       fit in the dataset.  In this case, the size of the user_info array 
+*       (in bytes) must equal sizeof(float) * n_points * nfits.
+*
+* Parameters:
+* y = a*e^bx+c*e^dx;
+* parameters: An input vector of model parameters.
+*             p[0]: a 
+*             p[1]: b
+*             p[2]: c
+*             p[3]: d
+*
+* n_fits: The number of fits. (not used)
+*
+* n_points: The number of data points per fit.
+*
+* value: An output vector of model function values.
+*
+* derivative: An output vector of model function partial derivatives.
+*
+* point_index: The data point index.
+*
+* fit_index: The fit index. (not used)
+*
+* chunk_index: The chunk index. (not used)
+*
+* user_info: An input vector containing user information. 
+*
+* user_info_size: The size of user_info in bytes. 
+*
+* Calling the calculate_gauss1d function
+* ======================================
+*
+* This __device__ function can be only called from a __global__ function or an other
+* __device__ function.
+*
+*/
+
+__device__ void calculate_dualExp(
+    float const * parameters,
+    int const n_fits,
+    int const n_points,
+    float * value,
+    float * derivative,
+    int const point_index,
+    int const fit_index,
+    int const chunk_index,
+    char * user_info,
+    std::size_t const user_info_size)
+{
+    // indices
+
+    float * user_info_float = (float*)user_info;
+    float x = 0.0f;
+    if (!user_info_float)
+    {
+        x = point_index;
+    }
+    else if (user_info_size / sizeof(float) == n_points)
+    {
+        x = user_info_float[point_index];
+    }
+    else if (user_info_size / sizeof(float) > n_points)
+    {
+        int const chunk_begin = chunk_index * n_fits * n_points;
+        int const fit_begin = fit_index * n_points;
+        x = user_info_float[chunk_begin + fit_begin + point_index];
+    }
+
+    // parameters
+
+    float const * p = parameters;
+    
+    // value
+
+    //float const argx = (x - p[1]) * (x - p[1]) / (2 * p[2] * p[2]);
+    //float const ex = exp(-argx);
+    value[point_index] = p[0] * exp(p[1]*x) + p[2]*exp(p[3]*x);
+
+    // derivative
+
+    float * current_derivative = derivative + point_index;
+
+    current_derivative[0 * n_points]  = exp(p[1]*x);
+    current_derivative[1 * n_points]  = p[0] * exp(p[1]*x)*x;
+    current_derivative[2 * n_points]  = exp(p[3]*x);
+    current_derivative[3 * n_points]  = p[2] * exp(p[3]*x)*x;
+}
+
+#endif

--- a/Gpufit/models/models.cuh
+++ b/Gpufit/models/models.cuh
@@ -7,9 +7,9 @@
 #include "gauss_2d_elliptic.cuh"
 #include "gauss_2d_rotated.cuh"
 #include "cauchy_2d_elliptic.cuh"
-
+#include "dual_exp.cuh"
 __device__ void calculate_model(
-    ModelID const model_id,
+    int const model_id,
     float const * parameters,
     int const n_fits,
     int const n_points,
@@ -41,12 +41,15 @@ __device__ void calculate_model(
     case LINEAR_1D:
         calculate_linear1d(parameters, n_fits, n_points, value, derivative, point_index, fit_index, chunk_index, user_info, user_info_size);
         break;
+	case DUAL_EXP:	
+        calculate_dualExp(parameters, n_fits, n_points, value, derivative, point_index, fit_index, chunk_index, user_info, user_info_size);
+        break;
     default:
         break;
     }
 }
 
-void configure_model(ModelID const model_id, int & n_parameters, int & n_dimensions)
+void configure_model(int const model_id, int & n_parameters, int & n_dimensions)
 {
     switch (model_id)
     {
@@ -56,8 +59,9 @@ void configure_model(ModelID const model_id, int & n_parameters, int & n_dimensi
     case GAUSS_2D_ROTATED:      n_parameters = 7; n_dimensions = 2; break;
     case CAUCHY_2D_ELLIPTIC:    n_parameters = 6; n_dimensions = 2; break;
     case LINEAR_1D:             n_parameters = 2; n_dimensions = 1; break;
+	case DUAL_EXP:              n_parameters = 4; n_dimensions = 1; break;
     default:                                                        break;
     }
 }
 
-#endif // GPUFIT_MODELS_CUH_INCLUDED
+#endif


### PR DESCRIPTION
Discussion at [issue #31](https://github.com/gpufit/Gpufit/issues/31)
Output_parameters turn out to be all-zero inexplicably when n_fits is
set up to large enough.
In this example, it is bound up with available_gpu_memory_ =
std::size_t(double(free_bytes) * 0.1) in line 14, info.cu