### PR TITLE
Expose cpufit API to python

### DIFF
--- a/Cpufit/lm_fit_cpp.cpp
+++ b/Cpufit/lm_fit_cpp.cpp
@@ -816,11 +816,11 @@ void LMFitCPP::calc_values_gauss2delliptic(std::vector<REAL>& gaussian)
     int const size_y = size_x;
     for (int iy = 0; iy < size_y; iy++)
     {
+        REAL const argy = (iy - parameters_[2]) * (iy - parameters_[2]) / (2 * parameters_[4] * parameters_[4]);
         for (int ix = 0; ix < size_x; ix++)
         {
-            REAL argx = (ix - parameters_[1]) * (ix - parameters_[1]) / (2 * parameters_[3] * parameters_[3]);
-            REAL argy = (iy - parameters_[2]) * (iy - parameters_[2]) / (2 * parameters_[4] * parameters_[4]);
-            REAL ex = exp(-(argx + argy));
+            REAL const argx = (ix - parameters_[1]) * (ix - parameters_[1]) / (2 * parameters_[3] * parameters_[3]);
+            REAL const ex = exp(-(argx + argy));
 
             gaussian[iy*size_x + ix]
                 = parameters_[0] * ex + parameters_[5];

--- a/Gpufit/info.cpp
+++ b/Gpufit/info.cpp
@@ -1,5 +1,6 @@
 #include "info.h"
 #include <algorithm>
+#include <limits>
 
 Info::Info() :
     n_parameters_(0),

--- a/Gpufit/python/CMakeLists.txt
+++ b/Gpufit/python/CMakeLists.txt
@@ -17,9 +17,9 @@ set( module_files
 )
 
 if ( USE_CUBLAS AND DEFINED CUBLAS_DLL )
-	set( binary $<TARGET_FILE:Gpufit> ${CUBLAS_DLL} )
+	set( binary $<TARGET_FILE:Gpufit> ${CUBLAS_DLL} $<TARGET_FILE:Cpufit> )
 else()
-	set( binary $<TARGET_FILE:Gpufit> )
+	set( binary $<TARGET_FILE:Gpufit> $<TARGET_FILE:Cpufit> )
 endif()
 
 add_custom_target( PYTHON_PACKAGE

--- a/Gpufit/python/tests/test_gaussian_fit_1d.py
+++ b/Gpufit/python/tests/test_gaussian_fit_1d.py
@@ -26,7 +26,7 @@ def generate_gauss_1d(parameters, x):
 
 class Test(unittest.TestCase):
 
-    def test_gaussian_fit_1d(self):
+    def test_gpufit(self):
         # constants
         n_fits = 1
         n_points = 5
@@ -53,6 +53,9 @@ class Test(unittest.TestCase):
         initial_parameters = np.empty((n_fits, n_parameter), dtype=np.float32)
         initial_parameters[0, :] = (2, 1.5, 0.3, 0)
 
+        print("\n=== Gpufit test gauss 1d: ===")
+        self.assertTrue(gf.cuda_available(), msg=gf.get_last_error())
+
         # call to gpufit
         parameters, states, chi_squares, number_iterations, execution_time = gf.fit(data, None, model_id,
                                                                                     initial_parameters, tolerance, \
@@ -66,14 +69,59 @@ class Test(unittest.TestCase):
         print('iterations: {}'.format(number_iterations))
         print('time: {} s'.format(execution_time))
 
-        assert (chi_squares < 1e-6)
-        assert (states == 0)
-        assert (number_iterations <= max_n_iterations)
+        self.assertTrue(chi_squares < 1e-6)
+        self.assertTrue(states == 0)
+        self.assertTrue(number_iterations <= max_n_iterations)
         for i in range(n_parameter):
-            assert (abs(true_parameters[i] - parameters[0, i]) < 1e-6)
+            self.assertTrue(abs(true_parameters[i] - parameters[0, i]) < 1e-6)
+
+    def test_cpufit(self):
+        # constants
+        n_fits = 1
+        n_points = 5
+        n_parameter = 4  # model will be GAUSS_1D
+
+        # true parameters
+        true_parameters = np.array((4, 2, 0.5, 1), dtype=np.float32)
+
+        # generate data
+        data = np.empty((n_fits, n_points), dtype=np.float32)
+        x = np.arange(n_points, dtype=np.float32)
+        data[0, :] = generate_gauss_1d(true_parameters, x)
+
+        # tolerance
+        tolerance = 0.001
+
+        # max_n_iterations
+        max_n_iterations = 10
+
+        # model id
+        model_id = gf.ModelID.GAUSS_1D
+
+        # initial parameters
+        initial_parameters = np.empty((n_fits, n_parameter), dtype=np.float32)
+        initial_parameters[0, :] = (2, 1.5, 0.3, 0)
+
+        print("\n=== Cpufit test gauss 1d: ===")
+
+        # call to cpufit
+        parameters, states, chi_squares, number_iterations, execution_time = gf.fit(data, None, model_id,
+                                                                                    initial_parameters, tolerance, \
+                                                                                    max_n_iterations, None, None, None, platform="cpu")
+
+        # print results
+        for i in range(n_parameter):
+            print(' p{} true {} fit {}'.format(i, true_parameters[i], parameters[0, i]))
+        print('fit state : {}'.format(states))
+        print('chi square: {}'.format(chi_squares))
+        print('iterations: {}'.format(number_iterations))
+        print('time: {} s'.format(execution_time))
+
+        self.assertTrue(chi_squares < 1e-6)
+        self.assertTrue(states == 0)
+        self.assertTrue(number_iterations <= max_n_iterations)
+        for i in range(n_parameter):
+            self.assertTrue(abs(true_parameters[i] - parameters[0, i]) < 1e-6)
 
 if __name__ == '__main__':
-
-    if not gf.cuda_available():
-        raise RuntimeError(gf.get_last_error())
     unittest.main()

--- a/Gpufit/python/tests/test_linear_regression.py
+++ b/Gpufit/python/tests/test_linear_regression.py
@@ -8,7 +8,7 @@ import pygpufit.gpufit as gf
 
 class Test(unittest.TestCase):
 
-    def test_gaussian_fit_1d(self):
+    def test_gpufit(self):
         # constants
         n_fits = 1
         n_points = 2
@@ -37,6 +37,9 @@ class Test(unittest.TestCase):
         # user info
         user_info = np.array((0, 1), dtype=np.float32)
 
+        print("\n=== Gpufit test linear regression: ===")
+        self.assertTrue(gf.cuda_available(), msg=gf.get_last_error())
+
         # call to gpufit
         parameters, states, chi_squares, number_iterations, execution_time = gf.fit(data, None, model_id,
                                                                                     initial_parameters, tolerance, \
@@ -50,14 +53,62 @@ class Test(unittest.TestCase):
         print('iterations: {}'.format(number_iterations))
         print('time: {} s'.format(execution_time))
 
-        assert (chi_squares < 1e-6)
-        assert (states == 0)
-        assert (number_iterations <= max_number_iterations)
+        self.assertTrue(chi_squares < 1e-6)
+        self.assertTrue(states == 0)
+        self.assertTrue(number_iterations <= max_number_iterations)
         for i in range(n_parameter):
-            assert (abs(true_parameters[i] - parameters[0, i]) < 1e-6)
+            self.assertTrue(abs(true_parameters[i] - parameters[0, i]) < 1e-6)
+
+    def test_cpufit(self):
+        # constants
+        n_fits = 1
+        n_points = 2
+        n_parameter = 2
+
+        # true parameters
+        true_parameters = np.array((0, 1), dtype=np.float32)
+
+        # data values
+        data = np.empty((n_fits, n_points), dtype=np.float32)
+        data[0, :] = (0, 1)
+
+        # max number iterations
+        max_number_iterations = 10
+
+        # initial parameters
+        initial_parameters = np.empty((n_fits, n_parameter), dtype=np.float32)
+        initial_parameters[0, :] = (0, 0)
+
+        # model id
+        model_id = gf.ModelID.LINEAR_1D
+
+        # tolerance
+        tolerance = 0.001
+
+        # user info
+        user_info = np.array((0, 1), dtype=np.float32)
+
+        print("\n=== Cpufit test linear regression: ===")
+
+        # call to cpufit
+        parameters, states, chi_squares, number_iterations, execution_time = gf.fit(data, None, model_id,
+                                                                                    initial_parameters, tolerance, \
+                                                                                    None, None, None, user_info, platform="cpu")
+
+        # print results
+        for i in range(n_parameter):
+            print(' p{} true {} fit {}'.format(i, true_parameters[i], parameters[0, i]))
+        print('fit state : {}'.format(states))
+        print('chi square: {}'.format(chi_squares))
+        print('iterations: {}'.format(number_iterations))
+        print('time: {} s'.format(execution_time))
+
+        self.assertTrue(chi_squares < 1e-6)
+        self.assertTrue(states == 0)
+        self.assertTrue(number_iterations <= max_number_iterations)
+        for i in range(n_parameter):
+            self.assertTrue(abs(true_parameters[i] - parameters[0, i]) < 1e-6)
 
 if __name__ == '__main__':
 
-    if not gf.cuda_available():
-        raise RuntimeError(gf.get_last_error())
     unittest.main()

--- a/tests/Consistency.cpp
+++ b/tests/Consistency.cpp
@@ -27,12 +27,52 @@ void generate_input_linear_fit_1d(FitInput & i)
 	i.initial_parameters = { 0, 0 };
 	i.parameters_to_fit = { 1, 1 };
 
+	// constraints
+	i.constraints = { -2, 2, -2, 2 };
+	i.constraint_types = { LOWER_UPPER, LOWER_UPPER };
+
 	// tolerance and max_n_iterations
 	i.tolerance = 0.001f;
 	i.max_n_iterations = 10;
 
 	// user info
 	i.user_info_ = { 0., 1. };
+
+	i.expected_parameters = { 0., 1.};
+}
+
+
+void generate_input_linear_fit_1d_fail(FitInput & i)
+{
+	// number fits, points, parameters
+	i.n_fits = 1;
+	i.n_points = 2;
+	i.n_parameters = 2; // LINEAR_1D has two parameters
+
+	// data and weights
+	i.data = { 0, 1 };
+	i.weights_ = { 1, 1 };
+
+	// model id and estimator id
+	i.model_id = LINEAR_1D;
+	i.estimator_id = LSE;
+
+	// initial parameters and parameters to fit
+	i.initial_parameters = { 0, 0 };
+	i.parameters_to_fit = { 1, 1 };
+
+	// constraints
+	i.constraints = { -2, 0.5, -2, 0.5 };
+	i.constraint_types = { LOWER_UPPER, LOWER_UPPER };
+
+	// tolerance and max_n_iterations
+	i.tolerance = 0.001f;
+	i.max_n_iterations = 10;
+
+	// user info
+	i.user_info_ = { 0., 1. };
+
+	i.expected_parameters = { 0., 1.};
 }
 
 void generate_input_gauss_fit_1d(FitInput & i)
@@ -56,12 +96,18 @@ void generate_input_gauss_fit_1d(FitInput & i)
 	i.initial_parameters = { 2., 1.5, 0.3f, 0. };
 	i.parameters_to_fit = { 1, 1, 1, 1 };
 
+	// constraints
+	i.constraints = { 0., 5., 0., 5., 0., 1.0, -10., 10.  };
+	i.constraint_types = { LOWER_UPPER, LOWER_UPPER, LOWER_UPPER, LOWER_UPPER };
+
 	// tolerance and max_n_iterations
 	i.tolerance = 0.001f;
 	i.max_n_iterations = 10;
 
 	// user info
 	i.user_info_.clear(); // no user info
+
+	i.expected_parameters = true_parameters;
 }
 
 void generate_input_gauss_fit_2d(FitInput & i)
@@ -85,12 +131,18 @@ void generate_input_gauss_fit_2d(FitInput & i)
 	i.initial_parameters = { 2., 1.8f, 2.2f, 0.4f, 0. };
 	i.parameters_to_fit = { 1, 1, 1, 1, 1 };
 
+	// constraints
+	i.constraints = { 0., 5., 0., 5., 0., 5.0, 0., 1.0, -10., 10.  };
+	i.constraint_types = { LOWER_UPPER, LOWER_UPPER, LOWER_UPPER, LOWER_UPPER, LOWER_UPPER };
+
 	// tolerance and max_n_iterations
 	i.tolerance = 0.0001f;
 	i.max_n_iterations = 20;
 
 	// user info
 	i.user_info_.clear(); // no user info
+
+	i.expected_parameters = true_parameters;
 }
 
 void generate_input_gauss_fit_2d_elliptic(FitInput & i)
@@ -99,7 +151,7 @@ void generate_input_gauss_fit_2d_elliptic(FitInput & i)
     i.n_fits = 1;
     std::size_t const size_x = 5;
     i.n_points = size_x * size_x;
-    i.n_parameters = 6; // GAUSS_2D_ELLIPTIC has five parameters
+    i.n_parameters = 6; // GAUSS_2D_ELLIPTIC has six parameters
 
     // data and weights
     clean_resize(i.data, i.n_fits * i.n_points);
@@ -113,9 +165,13 @@ void generate_input_gauss_fit_2d_elliptic(FitInput & i)
     i.model_id = GAUSS_2D_ELLIPTIC;
     i.estimator_id = LSE;
 
-    // initial parameters and parameters to fit
+    // initial parameters and parameters to fit 
     i.initial_parameters = { 2, 1.8f, 2.2f, .5f, .5f, 0 };
-    i.parameters_to_fit = { 1, 1, 1, 1, 1 };
+    i.parameters_to_fit = { 1, 1, 1, 1, 1, 1 };
+
+   	// constraints
+	i.constraints = { 0., 5., 0., 5., 0., 5., 0., 1.0, 0., 1.0, -10., 10.  };
+	i.constraint_types = { LOWER_UPPER, LOWER_UPPER, LOWER_UPPER, LOWER_UPPER, LOWER_UPPER, LOWER_UPPER };
 
     // tolerance and max_n_iterations
     i.tolerance = 0.001f;
@@ -123,6 +179,165 @@ void generate_input_gauss_fit_2d_elliptic(FitInput & i)
 
     // user info
     i.user_info_.clear(); // no user info
+
+    i.expected_parameters = true_parameters;
+}
+
+void perform_cpufit_check(void (*func)(FitInput &) )
+{
+	// generate the data
+	FitInput i;
+	func(i);
+
+	// sanity checks (we don't want to introduce faulty data)
+	BOOST_CHECK(i.sanity_check());
+
+	FitOutput cpu;
+	clean_resize(cpu.parameters, i.n_fits * i.n_parameters);
+	clean_resize(cpu.states, i.n_fits);
+	clean_resize(cpu.chi_squares, i.n_fits);
+	clean_resize(cpu.n_iterations, i.n_fits);
+
+	// call to cpufit, store output
+	int const cpu_status
+		= cpufit
+		(
+			i.n_fits,
+			i.n_points,
+			i.data.data(),
+			i.weights(),
+			i.model_id,
+			i.initial_parameters.data(),
+			i.tolerance,
+			i.max_n_iterations,
+			i.parameters_to_fit.data(),
+			i.estimator_id,
+			i.user_info_size(),
+			i.user_info(),
+			cpu.parameters.data(),
+			cpu.states.data(),
+			cpu.chi_squares.data(),
+			cpu.n_iterations.data()
+		);
+
+	BOOST_CHECK(cpu_status == 0);
+
+	if (i.expected_parameters.size()) {
+		BOOST_CHECK(close_or_equal(i.expected_parameters, cpu.parameters));
+	}
+}
+
+
+void perform_cpufit_constrained_check(void (*func)(FitInput &) )
+{
+	// generate the data
+	FitInput i;
+	func(i);
+
+	// sanity checks (we don't want to introduce faulty data)
+	BOOST_CHECK(i.sanity_check());
+
+	FitOutput cpu;
+	clean_resize(cpu.parameters, i.n_fits * i.n_parameters);
+	clean_resize(cpu.states, i.n_fits);
+	clean_resize(cpu.chi_squares, i.n_fits);
+	clean_resize(cpu.n_iterations, i.n_fits);
+
+	// call to cpufit, store output
+	int const cpu_status
+		= cpufit_constrained
+		(
+			i.n_fits,
+			i.n_points,
+			i.data.data(),
+			i.weights(),
+			i.model_id,
+			i.initial_parameters.data(),
+			i.constraints.data(),
+			i.constraint_types.data(),
+			i.tolerance,
+			i.max_n_iterations,
+			i.parameters_to_fit.data(),
+			i.estimator_id,
+			i.user_info_size(),
+			i.user_info(),
+			cpu.parameters.data(),
+			cpu.states.data(),
+			cpu.chi_squares.data(),
+			cpu.n_iterations.data()
+		);
+
+	BOOST_CHECK(cpu_status == 0);
+
+	if (i.expected_parameters.size()) {
+		std::stringstream ss;
+		ss << "fit: ";
+		for (int j = 0; j < cpu.parameters.size(); j++)
+		    ss << cpu.parameters[j] << " ";
+		ss << " | true: ";
+		for (int j = 0; j < i.expected_parameters.size(); j++)
+		    ss << i.expected_parameters[j] << " ";
+
+		BOOST_TEST_MESSAGE(ss.str());
+
+		BOOST_CHECK(close_or_equal(i.expected_parameters, cpu.parameters));
+	}
+}
+
+void perform_cpufit_constrained_check_failure(void (*func)(FitInput &) )
+{
+	// generate the data
+	FitInput i;
+	func(i);
+
+	// sanity checks (we don't want to introduce faulty data)
+	BOOST_CHECK(i.sanity_check());
+
+	FitOutput cpu;
+	clean_resize(cpu.parameters, i.n_fits * i.n_parameters);
+	clean_resize(cpu.states, i.n_fits);
+	clean_resize(cpu.chi_squares, i.n_fits);
+	clean_resize(cpu.n_iterations, i.n_fits);
+
+	// call to cpufit, store output
+	int const cpu_status
+		= cpufit_constrained
+		(
+			i.n_fits,
+			i.n_points,
+			i.data.data(),
+			i.weights(),
+			i.model_id,
+			i.initial_parameters.data(),
+			i.constraints.data(),
+			i.constraint_types.data(),
+			i.tolerance,
+			i.max_n_iterations,
+			i.parameters_to_fit.data(),
+			i.estimator_id,
+			i.user_info_size(),
+			i.user_info(),
+			cpu.parameters.data(),
+			cpu.states.data(),
+			cpu.chi_squares.data(),
+			cpu.n_iterations.data()
+		);
+
+	BOOST_CHECK(cpu_status == 0);	
+	if (i.expected_parameters.size()) {
+		std::stringstream ss;
+		ss << "fit: ";
+		for (int j = 0; j < cpu.parameters.size(); j++)
+		    ss << cpu.parameters[j] << " ";
+		ss << " | true: ";
+		for (int j = 0; j < i.expected_parameters.size(); j++)
+		    ss << i.expected_parameters[j] << " ";
+
+		BOOST_TEST_MESSAGE(ss.str());
+
+		// check for failure: bounds (purposefully) do not include expected param
+		BOOST_CHECK(!(close_or_equal(i.expected_parameters, cpu.parameters)));
+	}
 }
 
 void perform_cpufit_gpufit_and_check(void (*func)(FitInput &))
@@ -201,20 +416,254 @@ void perform_cpufit_gpufit_and_check(void (*func)(FitInput &))
 	BOOST_CHECK(close_or_equal(cpu.parameters, gpu.parameters));
 	BOOST_CHECK(close_or_equal(cpu.chi_squares, gpu.chi_squares));
 
+	if (i.expected_parameters.size()) {
+		BOOST_CHECK(close_or_equal(i.expected_parameters, cpu.parameters));
+		BOOST_CHECK(close_or_equal(i.expected_parameters, gpu.parameters));
+	}
+
 }
 
-BOOST_AUTO_TEST_CASE( Consistency )
+
+void perform_cpufit_gpufit_constrained_and_check(void (*func)(FitInput &))
 {
-	BOOST_TEST_MESSAGE( "linear_fit_1d" );
+	// generate the data
+	FitInput i;
+	func(i);
+
+	// sanity checks (we don't want to introduce faulty data)
+	BOOST_CHECK(i.sanity_check());
+	
+	// reset output variables
+	FitOutput gpu, cpu;
+	clean_resize(gpu.parameters, i.n_fits * i.n_parameters);
+	clean_resize(gpu.states, i.n_fits);
+	clean_resize(gpu.chi_squares, i.n_fits);
+	clean_resize(gpu.n_iterations, i.n_fits);
+
+	clean_resize(cpu.parameters, i.n_fits * i.n_parameters);
+	clean_resize(cpu.states, i.n_fits);
+	clean_resize(cpu.chi_squares, i.n_fits);
+	clean_resize(cpu.n_iterations, i.n_fits);
+
+
+	// call to cpufit, store output
+	int const cpu_status
+		= cpufit_constrained
+		(
+			i.n_fits,
+			i.n_points,
+			i.data.data(),
+			i.weights(),
+			i.model_id,
+			i.initial_parameters.data(),
+			i.constraints.data(),
+			i.constraint_types.data(),
+			i.tolerance,
+			i.max_n_iterations,
+			i.parameters_to_fit.data(),
+			i.estimator_id,
+			i.user_info_size(),
+			i.user_info(),
+			cpu.parameters.data(),
+			cpu.states.data(),
+			cpu.chi_squares.data(),
+			cpu.n_iterations.data()
+		);
+
+	BOOST_CHECK(cpu_status == 0);
+
+	// call to gpufit, store output
+	int const gpu_status
+		= gpufit_constrained
+		(
+			i.n_fits,
+			i.n_points,
+			i.data.data(),
+			i.weights(),
+			i.model_id,
+			i.initial_parameters.data(),
+			i.constraints.data(),
+			i.constraint_types.data(),
+			i.tolerance,
+			i.max_n_iterations,
+			i.parameters_to_fit.data(),
+			i.estimator_id,
+			i.user_info_size(),
+			i.user_info(),
+			gpu.parameters.data(),
+			gpu.states.data(),
+			gpu.chi_squares.data(),
+			gpu.n_iterations.data()
+		);
+
+	BOOST_CHECK(gpu_status == 0);
+
+	// check both output for equality
+	BOOST_CHECK(cpu.states == gpu.states);
+	BOOST_CHECK(cpu.n_iterations == gpu.n_iterations);
+	BOOST_CHECK(close_or_equal(cpu.parameters, gpu.parameters));
+	BOOST_CHECK(close_or_equal(cpu.chi_squares, gpu.chi_squares));
+
+	if (i.expected_parameters.size()) {
+		BOOST_CHECK(close_or_equal(i.expected_parameters, cpu.parameters));
+		BOOST_CHECK(close_or_equal(i.expected_parameters, gpu.parameters));
+	}
+
+}
+
+void perform_cpufit_gpufit_constrained_and_check_failure(void (*func)(FitInput &))
+{
+	// generate the data
+	FitInput i;
+	func(i);
+
+	// sanity checks (we don't want to introduce faulty data)
+	BOOST_CHECK(i.sanity_check());
+	
+	// reset output variables
+	FitOutput gpu, cpu;
+	clean_resize(gpu.parameters, i.n_fits * i.n_parameters);
+	clean_resize(gpu.states, i.n_fits);
+	clean_resize(gpu.chi_squares, i.n_fits);
+	clean_resize(gpu.n_iterations, i.n_fits);
+
+	clean_resize(cpu.parameters, i.n_fits * i.n_parameters);
+	clean_resize(cpu.states, i.n_fits);
+	clean_resize(cpu.chi_squares, i.n_fits);
+	clean_resize(cpu.n_iterations, i.n_fits);
+
+
+	// call to cpufit, store output
+	int const cpu_status
+		= cpufit_constrained
+		(
+			i.n_fits,
+			i.n_points,
+			i.data.data(),
+			i.weights(),
+			i.model_id,
+			i.initial_parameters.data(),
+			i.constraints.data(),
+			i.constraint_types.data(),
+			i.tolerance,
+			i.max_n_iterations,
+			i.parameters_to_fit.data(),
+			i.estimator_id,
+			i.user_info_size(),
+			i.user_info(),
+			cpu.parameters.data(),
+			cpu.states.data(),
+			cpu.chi_squares.data(),
+			cpu.n_iterations.data()
+		);
+
+	BOOST_CHECK(cpu_status == 0);
+
+	// call to gpufit, store output
+	int const gpu_status
+		= gpufit_constrained
+		(
+			i.n_fits,
+			i.n_points,
+			i.data.data(),
+			i.weights(),
+			i.model_id,
+			i.initial_parameters.data(),
+			i.constraints.data(),
+			i.constraint_types.data(),
+			i.tolerance,
+			i.max_n_iterations,
+			i.parameters_to_fit.data(),
+			i.estimator_id,
+			i.user_info_size(),
+			i.user_info(),
+			gpu.parameters.data(),
+			gpu.states.data(),
+			gpu.chi_squares.data(),
+			gpu.n_iterations.data()
+		);
+
+	BOOST_CHECK(gpu_status == 0);
+
+	// check both output for equality
+	BOOST_CHECK(cpu.states == gpu.states);
+	BOOST_CHECK(cpu.n_iterations == gpu.n_iterations);
+	BOOST_CHECK(close_or_equal(cpu.parameters, gpu.parameters));
+	BOOST_CHECK(close_or_equal(cpu.chi_squares, gpu.chi_squares));
+
+	if (i.expected_parameters.size()) {
+		// check for failure: bounds (purposefully) do not include expected param
+		BOOST_CHECK(~(close_or_equal(i.expected_parameters, cpu.parameters)));
+		BOOST_CHECK(~(close_or_equal(i.expected_parameters, gpu.parameters)));
+	}
+
+}
+
+BOOST_AUTO_TEST_CASE( Cpufit )
+{
+
+	BOOST_TEST_MESSAGE( "cpufit; linear_fit_1d" );
+	perform_cpufit_check(&generate_input_linear_fit_1d);
+
+	BOOST_TEST_MESSAGE( "cpufit; gauss_fit_1d" );
+	perform_cpufit_check(&generate_input_gauss_fit_1d);
+
+	BOOST_TEST_MESSAGE( "cpufit; gauss_fit_2d" );
+	perform_cpufit_check(&generate_input_gauss_fit_2d);
+
+    BOOST_TEST_MESSAGE("cpufit; gauss_fit_2d_elliptic");
+    perform_cpufit_check(&generate_input_gauss_fit_2d_elliptic);
+}
+
+BOOST_AUTO_TEST_CASE( Cpufit_Constrained )
+{
+	BOOST_TEST_MESSAGE( "cpufit; contrained; linear_fit_1d" );
+	perform_cpufit_constrained_check(&generate_input_linear_fit_1d);
+
+	BOOST_TEST_MESSAGE( "cpufit; contrained fail; linear_fit_1d" );
+	perform_cpufit_constrained_check_failure(&generate_input_linear_fit_1d_fail);
+
+	BOOST_TEST_MESSAGE( "cpufit; contrained; gauss_fit_1d" );
+	perform_cpufit_constrained_check(&generate_input_gauss_fit_1d);
+
+	BOOST_TEST_MESSAGE( "cpufit; contrained; gauss_fit_2d" );
+	perform_cpufit_constrained_check(&generate_input_gauss_fit_2d);
+
+    BOOST_TEST_MESSAGE( "cpufit; contrained; gauss_fit_2d_elliptic" );
+    perform_cpufit_constrained_check(&generate_input_gauss_fit_2d_elliptic);
+}
+
+BOOST_AUTO_TEST_CASE( Cpufit_Gpufit_Consistency )
+{
+
+	BOOST_TEST_MESSAGE( "cpufit,gpufit; linear_fit_1d" );
 	perform_cpufit_gpufit_and_check(&generate_input_linear_fit_1d);
 
-	BOOST_TEST_MESSAGE( "gauss_fit_1d" );
+	BOOST_TEST_MESSAGE( "cpufit,gpufit; gauss_fit_1d" );
 	perform_cpufit_gpufit_and_check(&generate_input_gauss_fit_1d);
 
-	BOOST_TEST_MESSAGE( "gauss_fit_2d" );
+	BOOST_TEST_MESSAGE( "cpufit,gpufit; gauss_fit_2d" );
 	perform_cpufit_gpufit_and_check(&generate_input_gauss_fit_2d);
 
-    BOOST_TEST_MESSAGE("gauss_fit_2d_elliptic");
+    BOOST_TEST_MESSAGE( "cpufit,gpufit; gauss_fit_2d_elliptic" );
     perform_cpufit_gpufit_and_check(&generate_input_gauss_fit_2d_elliptic);
+}
 
+BOOST_AUTO_TEST_CASE( Cpufit_Gpufit_Constrained_Consistency )
+{
+
+	BOOST_TEST_MESSAGE( "cpufit,gpufit; constrained; linear_fit_1d" );
+	perform_cpufit_gpufit_constrained_and_check(&generate_input_linear_fit_1d);
+
+	BOOST_TEST_MESSAGE( "cpufit,gpufit; constrained fail; linear_fit_1d" );
+	perform_cpufit_gpufit_constrained_and_check_failure(&generate_input_linear_fit_1d_fail);
+
+	BOOST_TEST_MESSAGE( "cpufit,gpufit; constrained; gauss_fit_1d" );
+	perform_cpufit_gpufit_constrained_and_check(&generate_input_gauss_fit_1d);
+
+	BOOST_TEST_MESSAGE( "cpufit,gpufit; constrained; gauss_fit_2d" );
+	perform_cpufit_gpufit_constrained_and_check(&generate_input_gauss_fit_2d);
+
+    BOOST_TEST_MESSAGE( "cpufit,gpufit; constrained; gauss_fit_2d_elliptic" );
+    perform_cpufit_gpufit_constrained_and_check(&generate_input_gauss_fit_2d_elliptic);
 }

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -36,7 +36,7 @@ void generate_gauss_2d(std::vector< REAL > & v, std::vector< REAL > const & p)
         {
             REAL const argx = ((i - p[1]) * (i - p[1]));
             REAL const ex = exp(-(argx + argy) / (2 * p[3] * p[3]));
-            v[j * n + i] = p[0] * ex + p[3];
+            v[j * n + i] = p[0] * ex + p[4];
         }
     }
 }
@@ -56,7 +56,7 @@ void generate_gauss_2d_elliptic(std::vector< REAL > & v, std::vector< REAL > con
         {
             REAL const argx = ((i - p[1]) * (i - p[1])) / (2 * p[3] * p[3]);
             REAL const ex = exp(-(argx + argy));
-            v[j * n + i] = p[0] * ex + p[3];
+            v[j * n + i] = p[0] * ex + p[5];
         }
     }
 }

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -126,10 +126,15 @@ struct FitInput
 	std::vector< REAL > initial_parameters;
 	std::vector< int > parameters_to_fit;
 
+	std::vector< REAL > constraints;
+	std::vector< int > constraint_types;
+
 	REAL tolerance;
 	int max_n_iterations;
 
 	std::vector< REAL > user_info_; // user info is REAL
+
+	std::vector< REAL> expected_parameters; // size zero to not check
 
 	REAL * weights()
 	{


### PR DESCRIPTION
Requirements to expose cpufit API to python:

- [x] Check cpufit builds fine, with cuda SDK but without a cuda compatible card - all good on linux
- [x] Cpufit tests pass without a cuda compatible card (few bugs in test suite, all sorted)
- [x] Add constrained fit to cpufit - this was actually already in master, by adrianjp88 (nice)
- [x] Decide if cpufit should be in pyGpufit or a new package (I think in pyGpufit makes more sense)
- [x] Decide how to expose cpufit. I kept the same API but added a keyword argument `platform='gpu'` by default, which could be changed to cpu fitting via `platform='cpu'`.

Now, assuming we expose cpufit in pyGpufit: 
- [x] Add simple logic to gpufit.py
- [x] The Cpufit library needs to be copied to the python dist folder.

Changes made:
  1. fix bugs in cpufit test functions
  2. add test for correctness in Consistency.cpp.
  3. add tests for cpufit alone (for when no gpu) to Consistency.cpp
  4. add simple tests for constrained fit in Consistency.cpp
  5. add cpufit api to pyGpufit

Related to #110