### PR TITLE
CI fixes to allow installing more cuda versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,20 @@ jobs:
             cuda: "11.3.1"
             visual_studio: "Visual Studio 16 2019"
             python: "3.9"
+            cmake_cxx_standard: "17"
           - os: windows-2019
             cuda: "11.4.0"
             visual_studio: "Visual Studio 16 2019"
             python: "3.9"
+            cmake_cxx_standard: "14"
           - os: ubuntu-20.04
             cuda: "11.3.1"
             python: "3.9"
+            cmake_cxx_standard: "14"
           - os: ubuntu-20.04
             cuda: "11.4.0"
             python: "3.9"
+            cmake_cxx_standard: "14"
 
     env:
       build_dir: "build"
@@ -93,9 +97,9 @@ jobs:
         run: |
           if [ "${{ runner.os }}" -eq "Windows" ]
           then
-            cmake . -B "${{ env.build_dir }}" -G "${{ matrix.visual_studio }}" -A x64
+            cmake . -B "${{ env.build_dir }}" -G "${{ matrix.visual_studio }}" -A x64 -DCMAKE_CXX_STANDARD=${{ os.cmake_cxx_standard }}
           else
-            cmake . -B "${{ env.build_dir }}" -DCMAKE_BUILD_TYPE=RELEASE
+            cmake . -B "${{ env.build_dir }}" -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_CXX_STANDARD=${{ os.cmake_cxx_standard }}
           fi
 
       - name: Configure Error Processing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.os }}, cuda ${{ matrix.cuda }}, ${{ matrix.python }}, ${{ matrix.visual_studio }}
+    name: ${{ matrix.os }}, cuda ${{ matrix.cuda }}, python ${{ matrix.python }}, ${{ matrix.visual_studio }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.os }}, cuda ${{ matrix.cuda }}, python ${{ matrix.python }}, ${{ matrix.visual_studio }}
+    name: ${{ matrix.os }}, cuda ${{ matrix.cuda }}, python ${{ matrix.python }}, C++${{ matrix.cmake_cxx_standard }}, ${{ matrix.visual_studio }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
         # `include` will only run specific combinations (not permutations of these)
         include:
           - os: windows-2019
+            cuda: "11.3.0"
+            visual_studio: "Visual Studio 16 2019"
+          - os: windows-2019
             cuda: "11.4.0"
             visual_studio: "Visual Studio 16 2019"
             python: "3.9"
@@ -46,7 +49,9 @@ jobs:
           pip install wheel
 
       - name: Install CUDA (Windows)
-        uses: Jimver/cuda-toolkit@v0.2.8
+        # uses: Jimver/cuda-toolkit@v0.2.8
+        # jimkring's branch adds support for more cuda versions
+        uses: jimkring/action-install-cuda-toolkit@master
         if: runner.os == 'Windows'
         with:
           sub-packages: '["nvcc", "visual_studio_integration", "cublas", "curand", "nvrtc", "cudart"]'
@@ -55,7 +60,9 @@ jobs:
           use-github-cache: false
 
       - name: Install CUDA (Linux)
-        uses: Jimver/cuda-toolkit@v0.2.8
+        # uses: Jimver/cuda-toolkit@v0.2.8
+        # jimkring's branch adds support for more cuda versions
+        uses: jimkring/action-install-cuda-toolkit@master
         if: runner.os == 'Linux'
         with:
           sub-packages: '["nvcc", "nvrtc", "cudart"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           - os: ubuntu-20.04
             cuda: "11.3.1"
             python: "3.9"
-            cmake_cxx_standard: "14"
+            cmake_cxx_standard: "17"
           - os: ubuntu-20.04
             cuda: "11.4.0"
             python: "3.9"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
         cuda: ["11.3.0", "11.4.0"]
         visual_studio: ["Visual Studio 16 2019"]
         python: ["3.9"]
-        exclude:
-          - os: ubuntu-20.04
-          - visual_studio: "Visual Studio 16 2019"
+        # exclude:
+        #   - os: ubuntu-20.04
+        #   - visual_studio: "Visual Studio 16 2019"
 
         # # `include` will only run specific combinations (not permutations of these)
         # include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,9 @@ jobs:
         run: |
           if [ "${{ runner.os }}" -eq "Windows" ]
           then
-            cmake . -B "${{ env.build_dir }}" -G "${{ matrix.visual_studio }}" -A x64 -DCMAKE_CXX_STANDARD=${{ os.cmake_cxx_standard }}
+            cmake . -B "${{ env.build_dir }}" -G "${{ matrix.visual_studio }}" -A x64 -DCMAKE_CXX_STANDARD=${{ matrix.cmake_cxx_standard }}
           else
-            cmake . -B "${{ env.build_dir }}" -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_CXX_STANDARD=${{ os.cmake_cxx_standard }}
+            cmake . -B "${{ env.build_dir }}" -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_CXX_STANDARD=${{ matrix.cmake_cxx_standard }}
           fi
 
       - name: Configure Error Processing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,22 +10,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # `include` will only run specific combinations (not permutations of these)
-        include:
-          - os: windows-2019
-            cuda: "11.3.0"
-            visual_studio: "Visual Studio 16 2019"
-            python: "3.9"
-          - os: windows-2019
-            cuda: "11.4.0"
-            visual_studio: "Visual Studio 16 2019"
-            python: "3.9"
+        os: [windows-2019, ubuntu-20.04]
+        cuda: ["11.3.0", "11.4.0"]
+        visual_studio: ["Visual Studio 16 2019"]
+        python: ["3.9"]
+        exclude:
           - os: ubuntu-20.04
-            cuda: "11.3.0"
-            python: "3.9"
-          - os: ubuntu-20.04
-            cuda: "11.4.0"
-            python: "3.9"
+          - visual_studio: ["Visual Studio 16 2019"]
+
+        # # `include` will only run specific combinations (not permutations of these)
+        # include:
+        #   - os: windows-2019
+        #     cuda: "11.3.0"
+        #     visual_studio: "Visual Studio 16 2019"
+        #     python: "3.9"
+        #   - os: windows-2019
+        #     cuda: "11.4.0"
+        #     visual_studio: "Visual Studio 16 2019"
+        #     python: "3.9"
+        #   - os: ubuntu-20.04
+        #     cuda: "11.3.0"
+        #     python: "3.9"
+        #   - os: ubuntu-20.04
+        #     cuda: "11.4.0"
+        #     python: "3.9"
 
     env:
       build_dir: "build"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install CUDA (Windows)
         # uses: Jimver/cuda-toolkit@v0.2.8
         # jimkring's branch adds support for more cuda versions
-        uses: jimkring/action-install-cuda-toolkit@master
+        uses: jimkring/action-install-cuda-toolkit@v0
         if: runner.os == 'Windows'
         with:
           sub-packages: '["nvcc", "visual_studio_integration", "cublas", "curand", "nvrtc", "cudart"]'
@@ -67,7 +67,7 @@ jobs:
       - name: Install CUDA (Linux)
         # uses: Jimver/cuda-toolkit@v0.2.8
         # jimkring's branch adds support for more cuda versions
-        uses: jimkring/action-install-cuda-toolkit@master
+        uses: jimkring/action-install-cuda-toolkit@v0
         if: runner.os == 'Linux'
         with:
           sub-packages: '["nvcc", "nvrtc", "cudart"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         python: ["3.9"]
         exclude:
           - os: ubuntu-20.04
-          - visual_studio: ["Visual Studio 16 2019"]
+          - visual_studio: "Visual Studio 16 2019"
 
         # # `include` will only run specific combinations (not permutations of these)
         # include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
+    name: ${{ matrix.os }}, cuda ${{ matrix.cuda }}, ${{ matrix.python }}, ${{ matrix.visual_studio }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
             visual_studio: "Visual Studio 16 2019"
             python: "3.9"
           - os: ubuntu-20.04
+            cuda: "11.3.0"
+            python: "3.9"
+          - os: ubuntu-20.04
             cuda: "11.4.0"
             python: "3.9"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           - os: windows-2019
             cuda: "11.3.0"
             visual_studio: "Visual Studio 16 2019"
+            python: "3.9"
           - os: windows-2019
             cuda: "11.4.0"
             visual_studio: "Visual Studio 16 2019"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,30 +10,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, ubuntu-20.04]
-        cuda: ["11.3.0", "11.4.0"]
-        visual_studio: ["Visual Studio 16 2019"]
-        python: ["3.9"]
-        # exclude:
-        #   - os: ubuntu-20.04
-        #   - visual_studio: "Visual Studio 16 2019"
-
-        # # `include` will only run specific combinations (not permutations of these)
-        # include:
-        #   - os: windows-2019
-        #     cuda: "11.3.0"
-        #     visual_studio: "Visual Studio 16 2019"
-        #     python: "3.9"
-        #   - os: windows-2019
-        #     cuda: "11.4.0"
-        #     visual_studio: "Visual Studio 16 2019"
-        #     python: "3.9"
-        #   - os: ubuntu-20.04
-        #     cuda: "11.3.0"
-        #     python: "3.9"
-        #   - os: ubuntu-20.04
-        #     cuda: "11.4.0"
-        #     python: "3.9"
+        # `include` will only run specific combinations (not permutations of these)
+        include:
+          - os: windows-2019
+            cuda: "11.3.1"
+            visual_studio: "Visual Studio 16 2019"
+            python: "3.9"
+          - os: windows-2019
+            cuda: "11.4.0"
+            visual_studio: "Visual Studio 16 2019"
+            python: "3.9"
+          - os: ubuntu-20.04
+            cuda: "11.3.1"
+            python: "3.9"
+          - os: ubuntu-20.04
+            cuda: "11.4.0"
+            python: "3.9"
 
     env:
       build_dir: "build"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,20 +17,16 @@ jobs:
             cuda: "11.3.1"
             visual_studio: "Visual Studio 16 2019"
             python: "3.9"
-            cmake_cxx_standard: "17"
           - os: windows-2019
             cuda: "11.4.0"
             visual_studio: "Visual Studio 16 2019"
             python: "3.9"
-            cmake_cxx_standard: "14"
           - os: ubuntu-20.04
             cuda: "11.3.1"
             python: "3.9"
-            cmake_cxx_standard: "17"
           - os: ubuntu-20.04
             cuda: "11.4.0"
             python: "3.9"
-            cmake_cxx_standard: "14"
 
     env:
       build_dir: "build"
@@ -97,9 +93,9 @@ jobs:
         run: |
           if [ "${{ runner.os }}" -eq "Windows" ]
           then
-            cmake . -B "${{ env.build_dir }}" -G "${{ matrix.visual_studio }}" -A x64 -DCMAKE_CXX_STANDARD=${{ matrix.cmake_cxx_standard }}
+            cmake . -B "${{ env.build_dir }}" -G "${{ matrix.visual_studio }}" -A x64
           else
-            cmake . -B "${{ env.build_dir }}" -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_CXX_STANDARD=${{ matrix.cmake_cxx_standard }}
+            cmake . -B "${{ env.build_dir }}" -DCMAKE_BUILD_TYPE=RELEASE
           fi
 
       - name: Configure Error Processing


### PR DESCRIPTION
I have tweaked the ci.yml action to use [my own fork of the cuda-toolkit github action](https://github.com/jimkring/action-install-cuda-toolkit), which adds support for all versions of cuda-tookit 11.x.x (many of which were missing in Windows -- some missing in Ubuntu).

FYI: I also opened a pull request in the Jimver/cuda-toolkit project to accept my changes  [(Jimver/cuda-toolkit/pull/163)](https://github.com/Jimver/cuda-toolkit/pull/163) in that project to see if they'll include my fixes.