### PR TITLE
Fix import problem in pycpufit

### DIFF
--- a/Cpufit/python/pycpufit/__init__.py
+++ b/Cpufit/python/pycpufit/__init__.py
@@ -1,1 +1,1 @@
-from cpufit import *
+from pycpufit.cpufit import *


### PR DESCRIPTION
The import statement in `Cpufit/python/pycpufit/__init__.py` causes this error:

```
Traceback (most recent call last):
  File "Gpufit/build/pyCpufit/setup.py", line 10, in <module>
    import pycpufit.version as vs
  File "Gpufit/build/pyCpufit/pycpufit/__init__.py", line 1, in <module>
    from cpufit import *
```

This commit makes the import fully qualififed.

Fixes: #129, #128 