### PR TITLE
Add CUDA path to the search path when loading Gpufit.dll

### DIFF
--- a/Gpufit/python/pygpufit/gpufit.py
+++ b/Gpufit/python/pygpufit/gpufit.py
@@ -21,7 +21,17 @@ elif os.name == 'posix':
 else:
     raise RuntimeError('OS {} not supported by pyGpufit.'.format(os.name))
 
+cuda_path = None
+# add CUDA_PATH to the dll search path
+if os.name == 'nt' and hasattr(os, 'add_dll_directory') and 'CUDA_PATH' in os.environ:    
+    cuda_path = os.add_dll_directory(
+        os.path.join(os.environ['CUDA_PATH'], 'bin'))
+# load the GpuFit library
 lib = cdll.LoadLibrary(lib_path)
+# remove CUDA_PATH from the dll search path
+if cuda_path is not None:
+    cuda_path.close()
+del cuda_path
 
 # gpufit_constrained function in the dll
 gpufit_func = lib.gpufit_constrained

--- a/Gpufit/python/pygpufit/gpufit.py
+++ b/Gpufit/python/pygpufit/gpufit.py
@@ -6,6 +6,7 @@ The binding is based on ctypes.
 See https://docs.python.org/3.5/library/ctypes.html, http://www.scipy-lectures.org/advanced/interfacing_with_c/interfacing_with_c.html
 """
 
+from genericpath import isdir
 import os
 import time
 from ctypes import cdll, POINTER, byref, c_int, c_float, c_char, c_char_p, c_size_t
@@ -21,17 +22,21 @@ elif os.name == 'posix':
 else:
     raise RuntimeError('OS {} not supported by pyGpufit.'.format(os.name))
 
-cuda_path = None
+cuda_paths = []
 # add CUDA_PATH to the dll search path
 if os.name == 'nt' and hasattr(os, 'add_dll_directory') and 'CUDA_PATH' in os.environ:    
-    cuda_path = os.add_dll_directory(
+    cuda_paths.append ( os.add_dll_directory(
         os.path.join(os.environ['CUDA_PATH'], 'bin'))
+    )
+    cuda_bix_x64 = os.path.join(os.environ['CUDA_PATH'], 'bin/x64')
+    if os.path.isdir(cuda_bix_x64):
+        cuda_paths.append( os.add_dll_directory(cuda_bix_x64) )
 # load the GpuFit library
 lib = cdll.LoadLibrary(lib_path)
 # remove CUDA_PATH from the dll search path
-if cuda_path is not None:
+for cuda_path in cuda_paths:
     cuda_path.close()
-del cuda_path
+del cuda_paths
 
 # gpufit_constrained function in the dll
 gpufit_func = lib.gpufit_constrained


### PR DESCRIPTION
When running
```Python
import pygpufit.gpufit as gf
```
I got the error
```Could not find module 'C:\Users\myuser\.venv\Lib\site-packages\pygpufit\Gpufit.dll' (or one of its dependencies). Try using the full path with constructor syntax.```.

I realised that is because, even though CUDA was installed and its path added to the 'path' environment variable, the import was not looking for dependencies in there (I guess because of [this](https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew)).

When I added the CUDA path (as read from the CUDA_PATH environment variable) to the DLL search path, the import worked for me. 

It might also fix issue #134 